### PR TITLE
Use multibyte substr() for createExcerpt()

### DIFF
--- a/classes/Result.php
+++ b/classes/Result.php
@@ -199,7 +199,7 @@ class Result
 
         // The relevant part is in the middle of the string, so surround
         // it with ...
-        return '...' . trim(substr($text, $start, $length)) . '...';
+        return '...' . trim(mb_substr($text, $start, $length)) . '...';
     }
 
 


### PR DESCRIPTION
At the moment, substr() function is used to create excerpt when it is in the middle of text. But when the text is not in English, substr() could break characters at the start and at the end of the excerpt, resulting in weird symbols.
The solution is to use the multi-byte version: mb_substr().
This PR proposes just that.