### PR TITLE
Use multibyte strtolower in StaticPages results provider

### DIFF
--- a/classes/providers/RainlabPagesResultsProvider.php
+++ b/classes/providers/RainlabPagesResultsProvider.php
@@ -79,7 +79,7 @@ class RainlabPagesResultsProvider extends ResultsProvider
     {
         return is_array($subject)
             ? $this->arrayContainsQuery($subject)
-            : mb_strpos(strtolower($subject), strtolower($this->query)) !== false;
+            : mb_strpos(mb_strtolower($subject), mb_strtolower($this->query)) !== false;
     }
 
     /**


### PR DESCRIPTION
At the moment, search results for RainLab Static Pages are case-sensitive for non-English texts due to strtolower() calls. Proposed solution: use multibyte version: mb_strtolower().