### PR TITLE
Grouped orWheres so they wont be on one level with isPublished()

### DIFF
--- a/classes/providers/RainlabBlogResultsProvider.php
+++ b/classes/providers/RainlabBlogResultsProvider.php
@@ -76,9 +76,11 @@ class RainlabBlogResultsProvider extends ResultsProvider
     {
         return Post::isPublished()
                    ->with(['featured_images'])
-                   ->where('title', 'like', "%{$this->query}%")
-                   ->orWhere('content', 'like', "%{$this->query}%")
-                   ->orWhere('excerpt', 'like', "%{$this->query}%")
+                    ->where(function ($query) {
+                        $query->where('title', 'like', "%{$this->query}%")
+                            ->orWhere('content', 'like', "%{$this->query}%")
+                            ->orWhere('excerpt', 'like', "%{$this->query}%");
+                    })
                    ->orderBy('published_at', 'desc')
                    ->get();
     }


### PR DESCRIPTION
Hi

I accidentally found out that unpublished RainLab.Blog posts are still included into the search results. It happens because when we're building the query, where clause generated by isPublished() is on the same level as orWhere() clauses. It results in query like `WHERE published = 1 OR content LIKE "%query% OR ...` instead of `WHERE published = 1 AND (title like "%query%" OR content like "%query%")`

This PR groups search-related where clauses to fix the issue.