### PR TITLE
Excerpt markup fix

### DIFF
--- a/classes/Result.php
+++ b/classes/Result.php
@@ -190,7 +190,11 @@ class Result
     {
         $length = Settings::get('excerpt_length', 250);
 
-        $position = mb_strpos($text, '<mark>' . $this->query . '</mark>');
+        // lowercase text and query to find the first occurence
+        $lowered_text = mb_strtolower($text);
+        $lowered_query = mb_strtolower($this->query);
+      
+        $position = mb_strpos($lowered_text, '<mark>' . $lowered_query . '</mark>');
         $start    = (int)$position - ($length / 2);
 
         if ($start < 0) {

--- a/classes/Result.php
+++ b/classes/Result.php
@@ -198,12 +198,14 @@ class Result
         $start    = (int)$position - ($length / 2);
 
         if ($start < 0) {
-            return Str::limit($text, $length);
+            $excerpt = Str::limit($text, $length);
+        } else {
+            // The relevant part is in the middle of the string, so surround
+            // it with ...
+            $excerpt = '...' . trim(mb_substr($text, $start, $length)) . '...';
         }
-
-        // The relevant part is in the middle of the string, so surround
-        // it with ...
-        return '...' . trim(mb_substr($text, $start, $length)) . '...';
+        
+        return $this->checkBorders($excerpt);
     }
 
 
@@ -224,5 +226,27 @@ class Result
 
         return (string)preg_replace('/(' . preg_quote($this->query, '/') . ')/i', '<mark>$0</mark>', $text);
     }
-
+  
+  
+  /**
+   *
+   * Looks for unclosed/broken <mark> tag on the end of the excerpt and removes it
+   *
+   * @param string $excerpt
+   * @return string
+   */
+    protected function checkBorders($excerpt) {
+      
+        // count opening and closing tags
+        $openings = substr_count($excerpt, '<mark>');
+        $closings = substr_count($excerpt, '</mark>');
+        if ($openings != $closings) {
+          // last mark tag seems to be broken, remove it
+          $position = mb_strrpos($excerpt, '<mark>');
+          $excerpt = trim(mb_substr($excerpt, 0, $position)) . '...';
+        }
+      
+        return $excerpt;
+    }
+  
 }


### PR DESCRIPTION
This one fixes 2 related issues:

1) Lookup for position of query in text in createExcerpt() was case sensitive so the excerpt wasn't always centered on the marked query. To solve it I made the lookup with mb_strpos() to go over lowered versions of text and query.

2) The reason to look into createExcerpt() at all was that the markup of search results page sometimes appeared broken. After a little debugging I found that if another query instance occurs just at the end of the excerpt, the closing mark tag can be broken which will break the page markup. In this PR I propose to remove the last <mark>query</mark> instance if the closing tag is broken.

