### PR TITLE
Fix for case sensitive query mark

### DIFF
--- a/classes/Result.php
+++ b/classes/Result.php
@@ -239,7 +239,7 @@ class Result
             return $text;
         }
 
-        return (string)preg_replace('/(' . preg_quote($this->query, '/') . ')/i', '<mark>$0</mark>', $text);
+        return (string)preg_replace('/(' . preg_quote($this->query, '/') . ')/iu', '<mark>$0</mark>', $text);
     }
 
 


### PR DESCRIPTION
Hello

This one is small, just added 'u` to `preg_replace()` regex flags so that matching would go case-insensitive.