### PR TITLE
Make sure that `published_at` is Carbon object

### DIFF
--- a/classes/providers/RainlabBlogResultsProvider.php
+++ b/classes/providers/RainlabBlogResultsProvider.php
@@ -51,7 +51,13 @@ class RainlabBlogResultsProvider extends ResultsProvider
             $relevance = mb_stripos($post->title, $this->query) === false ? 1 : 2;
 
             if ($relevance > 1 && $post->published_at) {
-                $relevance -= $this->getAgePenalty($post->published_at->diffInDays(Carbon::now()));
+                $relevance -= $this->getAgePenalty(
+                    // Make sure that `published_at` is Carbon object
+                    (is_string($post->published_at)?
+                        (Carbon::parse($post->published_at)):
+                        $post->published_at
+                    )->diffInDays(Carbon::now())
+                );
             }
 
             $result        = new Result($this->query, $relevance);


### PR DESCRIPTION
For some reason, sometimes, Rainlab's Blog `$post->published_at` return as a string instead of `Carbon` object and show an error `Call to a member function diffInDays() on string`. 

This commit is to make sure it'll return as `Carbon` object by checking whether it's a string or not. If it is, I'll try to parse by using `Carbon::parse`. Then, do penalty things as usual.

![image](https://user-images.githubusercontent.com/3356814/56849285-dda3a180-691c-11e9-94b0-d527ccc2a6b7.png)
