### PR TITLE
Include query and controller parameters in offline.sitesearch.extend event.

### DIFF
--- a/classes/SearchService.php
+++ b/classes/SearchService.php
@@ -125,7 +125,7 @@ class SearchService
      */
     protected function additionalResultsProviders()
     {
-        $returns = collect(Event::fire('offline.sitesearch.extend'))->filter()->flatten();
+        $returns = collect(Event::fire('offline.sitesearch.extend', [$this->query, $this->controller]))->filter()->flatten();
 
         $returns->each(function ($return) {
             if ( ! $return instanceof ResultsProvider) {


### PR DESCRIPTION
Some of the native ResultsProviders (like the `RainlabBlogResultsProvider`) depend on the query and controller.
These additional parameters could also be useful when building your own ResultsProvider, or extending one of the included ResultsProviders.

This change should have minimal impact, and allow for some more flexibility when creating a new ResultsProvider.