### PR TITLE
Update ResultsProvider

### DIFF
--- a/classes/providers/ResultsProvider.php
+++ b/classes/providers/ResultsProvider.php
@@ -4,7 +4,7 @@ namespace OFFLINE\SiteSearch\Classes\Providers;
 
 use OFFLINE\SiteSearch\Classes\Result;
 use RainLab\Translate\Classes\Translator;
-use RainLab\Translate\Models\Locale;
+use RainLab\Translate\Classes\Locale;
 use System\Classes\PluginManager;
 use System\Models\File;
 


### PR DESCRIPTION
the locale model has been moved from `Rainlab\Translate\Modles` to `Rainlab\Models\Classes` (see https://github.com/rainlab/translate-plugin/blob/master/UPGRADE.md)

this led to an issue in october 3, where the plugin would not load becuase it oould not find the locale model